### PR TITLE
Add a supplier and supply chain in admin side

### DIFF
--- a/supplymap/app/views/home/index.html.erb
+++ b/supplymap/app/views/home/index.html.erb
@@ -8,6 +8,18 @@
     </div>
   </div>
 
+    <div class="row">
+      <div class="col-md-6">
+        <%= link_to new_supplier_path, class: "btn btn-success btn-md" do %>
+          <span> Add Supplier </span>
+        <% end %>
+      </div>
+      <div class="col-md-6">
+        <%= link_to new_supply_chain_path, class: "btn btn-success btn-md" do %>
+          <span> Add Supply Chain</span>
+        <% end %>
+    </div>
+
   <div class="row">
     <div class="col-md-6">
       <div class="list-group">


### PR DESCRIPTION
# Issue NUMBER(79)
Closes #79 

#Changes in this pull request
Add buttons to add suppliers and supply chain on the admin home page

#Screenshot or Gif of the FEATURE/THEME CHANGE/ OR VISUAL CHANGE
<img width="1437" alt="screen shot 2018-03-28 at 9 30 06 pm" src="https://user-images.githubusercontent.com/14128638/38065274-5959d760-32d0-11e8-9013-e6caa9209edf.png">
<img width="881" alt="screen shot 2018-03-28 at 9 34 50 pm" src="https://user-images.githubusercontent.com/14128638/38065280-6073f026-32d0-11e8-9086-3841e71cfa0e.png">
<img width="697" alt="screen shot 2018-03-28 at 9 35 06 pm" src="https://user-images.githubusercontent.com/14128638/38065282-61eb5426-32d0-11e8-87b8-ce2e8e454aa6.png">


